### PR TITLE
Add lint-staged for pre-commit linting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,2 @@
 pnpm test
-pnpm lint:format
-pnpm lint:format:package
+pnpm dlx lint-staged

--- a/package.json
+++ b/package.json
@@ -59,5 +59,9 @@
     "tailwindcss-animate": "^1",
     "typescript": "^5",
     "vitest": "^2"
+  },
+  "lint-staged": {
+    "src/**/*.ts": "prettier --config .prettierrc --write",
+    "./package.json": "prettier-package-json --write"
   }
 }


### PR DESCRIPTION
As currently configured, `prettier` is called during `pre-commit` and, if anything needs changing, will leave unstaged files behind i.e. you either have to run linting before committing or you'll find yourself having to do an extra commit with the prettier changes.

The change here is to use `lint-staged`:
* Only lints the files that were touched. 
* Will commit the results in the same commit.

Lastly, we use `pnpm dlx` to run `lint-staged` in `pre-commit` instead of `npx` for overall consistency/avoiding `npm`/`pnpm` spaghetti. 